### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,12 +1,12 @@
 HomeAssistant	KEYWORD1
-HomeAssistantService KEYWORD1
+HomeAssistantService	KEYWORD1
 
-begin KEYWORD2
-connected KEYWORD2
-wifiConnected KEYWORD2
-readState KEYWORD2
-readResponse KEYWORD2
-setEntityState KEYWORD2
-setEntityStateWithPayload KEYWORD2
-callService KEYWORD2
-callEntityService KEYWORD2
+begin	KEYWORD2
+connected	KEYWORD2
+wifiConnected	KEYWORD2
+readState	KEYWORD2
+readResponse	KEYWORD2
+setEntityState	KEYWORD2
+setEntityStateWithPayload	KEYWORD2
+callService	KEYWORD2
+callEntityService	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords